### PR TITLE
Update required terraform version to >=1.3.0.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=0.12.3"
+  required_version = ">=1.3.0"
 }
 
 data "aws_region" "current" {}


### PR DESCRIPTION
Since we now use optional type constraints, we must required a terraform version >=1.3.0.